### PR TITLE
Fixed the "browse items" hook.

### DIFF
--- a/ItemOrderPlugin.php
+++ b/ItemOrderPlugin.php
@@ -148,11 +148,11 @@ class ItemOrderPlugin extends Omeka_Plugin_AbstractPlugin
         }
                         
         // Do not filter if sorting by browse table header.
-        if (isset($_GET['sort_field'])) {
+        if (isset($params['sort_field'])) {
             return;
         }
-                
-        // Order the collection items by 1) whether an item order exists, 2) the 
+
+        // Order the collection items by 1) whether an item order exists, 2) the
         // item order, 3) the item ID.
         $select->joinLeft(array('item_order_item_orders' => $db->ItemOrder_ItemOrder), 'items.id = item_order_item_orders.item_id', array())
                ->reset('order')


### PR DESCRIPTION
Hi,

A little fix to avoid the hook to reorder items when another hook reordered them previously.

Sincerely,

Daniel Berthereau
Infodoc & Knowledge management
